### PR TITLE
batmon: cleanup blacklist

### DIFF
--- a/batmon.c
+++ b/batmon.c
@@ -31,19 +31,11 @@
 
 /** Skip these devices */
 static const char* blacklist[] = {
-  /* This driver should be removed from the kernel completely */
-  "rx51-battery",
-  /* Nokia N900 charger device is exposed as battery by UPower */
-  "bq24150a-0",
-  /* We want isp1704 on N900 */
-  "twl4030_ac",
-  /* We want isp1704 on N900 */
-  "twl4030_usb",
-  /* Another bogus battery (maybe like rx51-battery) */
-  "bq27000-battery"
-  /* Droid4 line power device (driver doesn't send uevents) */
-  "usb",
-  /* End of list */
+  /* List drivers to be blacklisted. The name is obtained from
+   * `upower -d`, and is the value of the `native-path` key for that
+   * upower device. Example:
+   * "rx51-battery",
+   */
   NULL
 };
 


### PR DESCRIPTION
Blacklisting of unneeded drivers for the N900 is now handled by a modprobe blocklist.

Additionally, the bq2415x driver was fixed so upower correctly sees it as a charger instead of a battery, thus it does not need to be blacklisted anymore.

The Droid 4 blacklist appears to have been added in error.