### PR TITLE
estimate percentage using voltage exported via upower

### DIFF
--- a/batmon.c
+++ b/batmon.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #include <gio/gio.h>
 #include <upower.h>
@@ -120,6 +121,48 @@ find_upower_devices()
   g_ptr_array_unref (devices);
 }
 
+/* Estimate percentage based on battery voltage if driver does not report it */
+static void
+refresh_capacity_estimation(void)
+{
+  BatteryData *data = &private.data;
+  gdouble upower_percentage;
+  gdouble delta;
+
+  /* data->percentage might contain an estimation, so fetch real value from upower */
+  g_object_get(private.battery, "percentage", &upower_percentage, NULL);
+
+  if (upower_percentage)
+    return;
+
+  if (!data->voltage_min)
+    data->voltage_min = 3.1;
+  if (!data->voltage_max)
+    data->voltage_max = 4.2;
+  delta = data->voltage_max - data->voltage_min;
+
+  if (data->voltage_now > (data->voltage_min + 0.2))
+  {
+    if (data->voltage_now <= (data->voltage_min + delta * 1.5 / 6))
+      data->percentage = 4;
+    else if (data->voltage_now <= (data->voltage_min + delta * 2.3 / 6))
+      data->percentage = 9;
+    else if (data->voltage_now <= (data->voltage_min + delta * 3 / 6))
+      data->percentage = 12;
+    else if (data->voltage_now <= (data->voltage_min + delta * 4 / 6))
+      data->percentage = 32;
+    else if (data->voltage_now <= (data->voltage_min + delta * 5 / 6))
+      data->percentage = 57;
+    else if (data->voltage_now <= (data->voltage_min + delta * 5.7 / 6))
+      data->percentage = 82;
+    else
+      data->percentage = 99;
+
+    /* Indicate that the capacity is an estimation */
+    data->estimating = true;
+  }
+}
+
 static void
 battery_prop_changed_cb(UpDevice *battery,
                         GParamSpec *pspec,
@@ -128,9 +171,12 @@ battery_prop_changed_cb(UpDevice *battery,
   BatteryData *data = &private.data;
   const gchar *prop = pspec->name;
 
-  if (!g_strcmp0(prop, "percentage"))
+  if (!g_strcmp0(prop, "percentage")) {
     g_object_get(battery, prop, &data->percentage,    NULL);
-  else if (!g_strcmp0(prop, "time-to-empty"))
+    /* The fuel gauge can start reporting percentage during runtime */
+    if (data->estimating)
+      data->estimating = false;
+  } else if (!g_strcmp0(prop, "time-to-empty"))
     g_object_get(battery, prop, &data->time_to_empty, NULL);
   else if (!g_strcmp0(prop, "time-to-full"))
     g_object_get(battery, prop, &data->time_to_full,  NULL);
@@ -138,7 +184,10 @@ battery_prop_changed_cb(UpDevice *battery,
     g_object_get(battery, prop, &data->charge_now,    NULL);
   else if (!g_strcmp0(prop, "charge-full"))
     g_object_get(battery, prop, &data->charge_full,   NULL);
-  else
+  else if (!g_strcmp0(prop, "voltage")) {
+    g_object_get(battery, prop, &data->voltage_now,  NULL);
+    refresh_capacity_estimation();
+  } else
     return;
 
   if (private.cb)
@@ -198,6 +247,8 @@ get_battery_properties(void)
 {
   BatteryData *data = &private.data;
 
+  data->estimating = false;
+
   g_object_get(private.battery,
                "percentage"   , &data->percentage,
                "state"        , &data->state,
@@ -205,7 +256,13 @@ get_battery_properties(void)
                "time-to-full" , &data->time_to_full,
                "charge"       , &data->charge_now,
                "charge-full"  , &data->charge_full,
+               "voltage"      , &data->voltage_now,
+               "voltage-min"  , &data->voltage_min,
+               "voltage-max"  , &data->voltage_max,
                NULL);
+
+  if (!data->percentage)
+    refresh_capacity_estimation();
 
   if (private.charger)
   {

--- a/batmon.h
+++ b/batmon.h
@@ -43,6 +43,12 @@ typedef struct {
   gdouble charge_now;
   /* The amount of charge when battery is full */
   gdouble charge_full;
+
+  /* For voltage-based estimations when battery is not calibrated */
+  gboolean estimating;
+  gdouble  voltage_now;
+  gdouble  voltage_min;
+  gdouble  voltage_max;
 } BatteryData;
 
 typedef void BatteryCallback (BatteryData *, void *);

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends:
  libdbus-1-dev,
  libdbus-glib-1-dev,
  libglib2.0-dev,
- libupower-glib-dev (>=0.99.7.5),
+ libupower-glib-dev,
  osso-af-settings
 Standards-Version: 3.7.3
 
@@ -29,6 +29,6 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
  mediaplayer-l10n-mr0,
  osso-sounds-ui,
  profiled (>= 0.0.3),
- upower (>=1:0.99.7.5)
+ upower
 Description: status area battery applet
  Battery applet for the status area. This will show the battery information.

--- a/status-area-applet-battery.c
+++ b/status-area-applet-battery.c
@@ -576,6 +576,8 @@ on_property_changed(BatteryData *batt_data, void *user_data)
 
   priv->percentage = (int)batt_data->percentage;
 
+  /* TODO: handle priv->estimating, e.g. show orange-themed battery icon */
+
   bars = (int)(8 *(6.25 + batt_data->percentage) / 100);
 
   switch(batt_data->state)


### PR DESCRIPTION
Works best with upower patched for exposing voltage_{min,max}_design [0]. Can work without however.

The voltage thresholds were chosen based on testing on Nokia N900, but should be reasonable for other devices.

[0] https://gitlab.freedesktop.org/upower/upower/-/merge_requests/259